### PR TITLE
fix: set search window for code block

### DIFF
--- a/src/consumer/index.ts
+++ b/src/consumer/index.ts
@@ -133,6 +133,23 @@ export class Consumer {
         return past ? {part, past} : null;
     };
 
+    setWindow(map: [number, number] | null | undefined, gap?: number) {
+        map = map || [0, this.lines.length - 1];
+        gap = gap || this.gap;
+
+        const [start, end] = [this.lines[map[0]] + gap, this.lines[map[1] + 1] || Infinity];
+
+        this.limits.push(end);
+
+        if (start >= this.cursor) {
+            this.cursor = start;
+        }
+    }
+
+    unsetWindow() {
+        this.limits.pop();
+    }
+
     private erule(tokens: Token[]) {
         try {
             return eruler(
@@ -182,23 +199,6 @@ export class Consumer {
         const dgap = gap - this.gap;
 
         this.cursor = start > -1 ? end - dgap : cursor - dgap;
-    }
-
-    private setWindow(map: [number, number] | null | undefined, gap?: number) {
-        map = map || [0, this.lines.length - 1];
-        gap = gap || this.gap;
-
-        const [start, end] = [this.lines[map[0]] + gap, this.lines[map[1] + 1] || Infinity];
-
-        this.limits.push(end);
-
-        if (start >= this.cursor) {
-            this.cursor = start;
-        }
-    }
-
-    private unsetWindow() {
-        this.limits.pop();
     }
 
     private line(pos: number) {

--- a/src/integration/__snapshots__/index.spec.ts.snap
+++ b/src/integration/__snapshots__/index.spec.ts.snap
@@ -279,6 +279,80 @@ exports[`integration computes valid sentenses: xliff main 1`] = `
 </xliff>"
 `;
 
+exports[`integration duplicate code block on diferent level: skeleton expr 1`] = `
+"- %%%1%%%
+
+    \`\`\`html
+    <p>first block</p>
+    <b>second block</b>
+    \`\`\`
+
+\`\`\`html
+<!-- Some text -->
+<p>first block</p>
+<b>second block</b>
+
+\`\`\`"
+`;
+
+exports[`integration duplicate code block on diferent level: skeleton main 1`] = `
+"- %%%0%%%
+
+    \`\`\`html
+    %%%1%%%
+    \`\`\`
+
+\`\`\`html
+%%%2%%%\`\`\`"
+`;
+
+exports[`integration duplicate code block on diferent level: xliff expr 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+    <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+        <header>
+            <skeleton>
+                <external-file href=\\"file.skl\\"></external-file>
+            </skeleton>
+        </header>
+        <body>
+            <trans-unit id=\\"1\\">
+                <source xml:space=\\"preserve\\">List item</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>"
+`;
+
+exports[`integration duplicate code block on diferent level: xliff main 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"file.skl\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"0\\">
+        <source xml:space=\\"preserve\\">List item</source>
+      </trans-unit>
+      <trans-unit id=\\"1\\">
+        <source xml:space=\\"preserve\\">&lt;p&gt;first block&lt;/p&gt;
+    &lt;b&gt;second block&lt;/b&gt;</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source xml:space=\\"preserve\\">&lt;!-- Some text --&gt;
+&lt;p&gt;first block&lt;/p&gt;
+&lt;b&gt;second block&lt;/b&gt;
+
+</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
 exports[`integration handle links with braces inside: skeleton expr 1`] = `"%%%1%%%"`;
 
 exports[`integration handle links with braces inside: skeleton main 1`] = `"%%%0%%%"`;
@@ -481,8 +555,6 @@ exports[`integration handles {#T} link within one paragraph: xliff main 1`] = `
 </xliff>"
 `;
 
-
-
 exports[`integration handles autolinks: skeleton expr 1`] = `
 "* %%%1%%%
 * %%%2%%%"
@@ -534,8 +606,6 @@ exports[`integration handles autolinks: xliff main 1`] = `
   </file>
 </xliff>"
 `;
-
-
 
 exports[`integration handles blockquotes: skeleton expr 1`] = `
 "> 1
@@ -1158,8 +1228,6 @@ exports[`integration handles html line breaks: xliff main 1`] = `
 </xliff>"
 `;
 
-
-
 exports[`integration handles image with empty title at the end of segment: skeleton expr 1`] = `"%%%1_s-1%%% %%%2_s-3%%%"`;
 
 exports[`integration handles image with empty title at the end of segment: skeleton main 1`] = `"%%%0%%% %%%1%%%"`;
@@ -1438,8 +1506,6 @@ exports[`integration handles inline includes: xliff main 1`] = `
   </file>
 </xliff>"
 `;
-
-
 
 exports[`integration handles link after abbreviation: skeleton expr 1`] = `"%%%1_s-1%%% %%%2_s-3%%%"`;
 

--- a/src/integration/index.spec.ts
+++ b/src/integration/index.spec.ts
@@ -442,3 +442,19 @@ test('handles {#T} link within one paragraph')`
 test('handle links with braces inside')`
     [Подробнее](https://ru.test.org/wiki/Аукцион_Викри#Механизм_Викри-Кларка-Гровса_(VCG_auction)_в_интернет-рекламе)
 `;
+
+test('duplicate code block on diferent level')`
+- List item
+
+    \`\`\`html
+    <p>first block</p>
+    <b>second block</b>
+    \`\`\`
+
+\`\`\`html
+<!-- Some text -->
+<p>first block</p>
+<b>second block</b>
+
+\`\`\`
+`;

--- a/src/skeleton/rules/index.ts
+++ b/src/skeleton/rules/index.ts
@@ -7,6 +7,7 @@ import {text} from './text';
 import {blockquote} from './blockquote';
 import {code} from './code';
 import {html} from './html';
+import {list} from './list';
 
 export const rules: Renderer.RenderRuleRecord = {
     ...text,
@@ -16,4 +17,5 @@ export const rules: Renderer.RenderRuleRecord = {
     ...blockquote,
     ...code,
     ...html,
+    ...list,
 };

--- a/src/skeleton/rules/list.ts
+++ b/src/skeleton/rules/list.ts
@@ -1,0 +1,36 @@
+import type Renderer from 'markdown-it/lib/renderer';
+import type {CustomRenderer} from 'src/renderer';
+
+import {Consumer} from 'src/consumer';
+import {find} from 'src/utils';
+
+export const list: Renderer.RenderRuleRecord = {
+    list_item_open: function (this: CustomRenderer<Consumer>, tokens: Token[], idx) {
+        const open = tokens[idx];
+        let close = find('list_item_close', tokens, idx + 1) as Token;
+
+        while (close?.level !== open.level) {
+            close = find('list_item_close', tokens, tokens.indexOf(close) + 1) as Token;
+        }
+        if (close?.level !== open.level) {
+            throw new Error('failed to find closed list item token');
+        }
+
+        this.state.setWindow(open.map);
+        close.open = open;
+
+        return '';
+    },
+    list_item_close: function (this: CustomRenderer<Consumer>, tokens: Token[], idx) {
+        const close = tokens[idx];
+        const open = close.open;
+
+        if (open?.type !== 'list_item_open') {
+            throw new Error('failed to render list item token');
+        }
+
+        this.state.unsetWindow();
+
+        return '';
+    },
+};


### PR DESCRIPTION
Если у нас есть кодблок внутри списка, 
а дальше по странице есть еще кодблок, который содержит полностью первый кодблок, то происходит некорректный поиск токена: он находится во втором блоке (так как в нем нету смещения)

```md
- list item

    ```html
    <p>first</p>
    <b>code block</b>
    ```

```html
<!-- Second code block -->
<p>first</p>
<b>code block</b>

\```


```