### PR TITLE
fix: add no-translate directive, rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.1.0",
+        "@diplodoc/directive": "^0.3.2",
         "@diplodoc/sentenizer": "^0.0.8",
         "@diplodoc/transform": "^4.10.0",
         "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",
@@ -1013,6 +1014,15 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "node_modules/@diplodoc/directive": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/directive/-/directive-0.3.2.tgz",
+      "integrity": "sha512-eIKI0T71FLzqq3UUYncS1U86BmpMVEkMgx+sqpIPcZEFMkGKNHRSzTzVDKdBi4EAEyuGCFoWgE7TLqWH5uH/UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "markdown-it-directive": "2.0.5"
       }
     },
     "node_modules/@diplodoc/lint": {
@@ -2970,8 +2980,7 @@
     "node_modules/@types/linkify-it": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.4.tgz",
-      "integrity": "sha512-hPpIeeHb/2UuCw06kSNAOVWgehBLXEo0/fUs0mw3W2qhqX89PI2yvok83MnuctYGCPrabGIoi0fFso4DQ+sNUQ==",
-      "dev": true
+      "integrity": "sha512-hPpIeeHb/2UuCw06kSNAOVWgehBLXEo0/fUs0mw3W2qhqX89PI2yvok83MnuctYGCPrabGIoi0fFso4DQ+sNUQ=="
     },
     "node_modules/@types/lodash": {
       "version": "4.17.5",
@@ -2983,7 +2992,6 @@
       "version": "13.0.9",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
       "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^3",
@@ -2993,8 +3001,7 @@
     "node_modules/@types/mdurl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.4.tgz",
-      "integrity": "sha512-ARVxjAEX5TARFRzpDRVC6cEk0hUIXCCwaMhz8y7S1/PxU6zZS1UMjyobz7q4w/D/R552r4++EhwmXK1N2rAy0A==",
-      "dev": true
+      "integrity": "sha512-ARVxjAEX5TARFRzpDRVC6cEk0hUIXCCwaMhz8y7S1/PxU6zZS1UMjyobz7q4w/D/R552r4++EhwmXK1N2rAy0A=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -10319,6 +10326,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.0.tgz",
       "integrity": "sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg=="
+    },
+    "node_modules/markdown-it-directive": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-directive/-/markdown-it-directive-2.0.5.tgz",
+      "integrity": "sha512-hpLYmcVeKR6hbXRK3OlJm4oVaFaBJg6JQ5E7j5Xo7K3QbTMbMqeLXvHdAr1MDIe3iNogJNamTaNycjkOUJg7cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/markdown-it": "^12.0.0 || ^13.0.0",
+        "markdown-it": "^12.0.0 || ^13.0.0"
+      }
     },
     "node_modules/markdown-it-meta": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "dependencies": {
     "@cospired/i18n-iso-languages": "^4.1.0",
+    "@diplodoc/directive": "^0.3.2",
     "@diplodoc/sentenizer": "^0.0.8",
     "@diplodoc/transform": "^4.10.0",
     "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -1,0 +1,1 @@
+export {noTranslate} from './no-translate';

--- a/src/directives/no-translate.ts
+++ b/src/directives/no-translate.ts
@@ -1,0 +1,69 @@
+import {
+    ContainerDirectiveParams,
+    LeafBlockDirectiveParams,
+    directiveParser,
+    registerContainerDirective,
+    registerInlineDirective,
+    registerLeafBlockDirective,
+    tokenizeBlockContent,
+    tokenizeInlineContent,
+} from '@diplodoc/directive';
+import MarkdownIt from 'markdown-it';
+import StateBlock from 'markdown-it/lib/rules_block/state_block';
+import StateInline from 'markdown-it/lib/rules_inline/state_inline';
+
+interface NoTranslateOptions {
+    mode?: 'render' | 'translate';
+}
+
+export function noTranslate(
+    options: NoTranslateOptions = {mode: 'translate'},
+): MarkdownIt.PluginSimple {
+    return (md) => {
+        md.use(directiveParser());
+
+        registerContainerDirective(
+            md,
+            'no-translate',
+            (state: StateBlock, params: ContainerDirectiveParams) => {
+                if (options.mode === 'translate') {
+                    state.push('no_translate_skip', '', 0);
+                } else if (params.content) {
+                    tokenizeBlockContent(state, params.content, 'no-translate');
+                }
+                return true;
+            },
+        );
+
+        registerLeafBlockDirective(
+            md,
+            'no-translate',
+            (state: StateBlock, params: LeafBlockDirectiveParams) => {
+                if (options.mode === 'translate') {
+                    state.push('no_translate_skip', '', 0);
+                } else if (params.inlineContent) {
+                    const content = params.inlineContent.raw;
+
+                    const html = md.render(content);
+
+                    const token = state.push('html_block', '', 0);
+                    token.content = html;
+                    token.map = [params.startLine, params.startLine + 1];
+                }
+                return true;
+            },
+        );
+
+        registerInlineDirective(md, 'no-translate', (state: StateInline, params) => {
+            if (options.mode === 'translate') {
+                const openToken = state.push('no_translate_inline', '', 1);
+                openToken.attrSet('data-content', params.content?.raw || '');
+            } else if (params.content) {
+                tokenizeInlineContent(state, params.content);
+            }
+            return true;
+        });
+
+        md.renderer.rules.no_translate_skip = () => '';
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export type {ExtractOptions, ComposeOptions, AjvOptions} from './api';
 export {extract, compose} from './api';
 export {linkRefs, unlinkRefs} from './json';
 export {CriticalProcessingError} from './consumer';
+export {noTranslate} from './directives';

--- a/src/integration/__snapshots__/index.spec.ts.snap
+++ b/src/integration/__snapshots__/index.spec.ts.snap
@@ -3345,6 +3345,165 @@ exports[`integration link variable leak: xliff main 1`] = `
 </xliff>"
 `;
 
+exports[`integration no-translate directive with block: skeleton expr 1`] = `
+"%%%1%%% 
+
+%%%2%%%
+### %%%3%%%
+%%%4_s-1%%%
+%%%5_s-3%%%
+:::"
+`;
+
+exports[`integration no-translate directive with block: skeleton main 1`] = `
+"%%%0%%% 
+
+:::no-translate
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+:::"
+`;
+
+exports[`integration no-translate directive with block: xliff expr 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+    <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+        <header>
+            <skeleton>
+                <external-file href=\\"file.skl\\"></external-file>
+            </skeleton>
+        </header>
+        <body>
+            <trans-unit id=\\"1\\">
+                <source xml:space=\\"preserve\\">This will be translated</source>
+            </trans-unit>
+            <trans-unit id=\\"2\\">
+                <source xml:space=\\"preserve\\">:::no-translate</source>
+            </trans-unit>
+            <trans-unit id=\\"3\\">
+                <source xml:space=\\"preserve\\">No-translate header</source>
+            </trans-unit>
+            <trans-unit id=\\"4_s-1\\">
+                <source xml:space=\\"preserve\\">Should not be translated.</source>
+            </trans-unit>
+            <trans-unit id=\\"5_s-3\\">
+                <source xml:space=\\"preserve\\">Can use <g equiv-text=\\"**{{text}}**\\" id=\\"e1\\" ctype=\\"bold\\" x-type=\\"strong\\" x-begin=\\"**\\" x-end=\\"**\\">markup</g> inside.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>"
+`;
+
+exports[`integration no-translate directive with block: xliff main 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"file.skl\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"0\\">
+        <source xml:space=\\"preserve\\">This will be translated</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`integration no-translate directive with inline: skeleton expr 1`] = `"%%%1%%%"`;
+
+exports[`integration no-translate directive with inline: skeleton main 1`] = `"%%%0%%%"`;
+
+exports[`integration no-translate directive with inline: xliff expr 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+    <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+        <header>
+            <skeleton>
+                <external-file href=\\"file.skl\\"></external-file>
+            </skeleton>
+        </header>
+        <body>
+            <trans-unit id=\\"1\\">
+                <source xml:space=\\"preserve\\">Use :no-translate[<g equiv-text=\\"**{{text}}**\\" id=\\"e1\\" ctype=\\"bold\\" x-type=\\"strong\\" x-begin=\\"**\\" x-end=\\"**\\">GET /api/v1/users</g>] to list users and :no-translate[POST /api/v1/users] to create.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>"
+`;
+
+exports[`integration no-translate directive with inline: xliff main 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"file.skl\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"0\\">
+        <source xml:space=\\"preserve\\">Use <x ctype=\\"no_translate_inline\\" equiv-text=\\":no-translate[**GET /api/v1/users**]\\" id=\\"g-test\\"/> to list users and <x ctype=\\"no_translate_inline\\" equiv-text=\\":no-translate[POST /api/v1/users]\\" id=\\"g-test\\"/> to create.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`integration no-translate directive with leaf: skeleton expr 1`] = `
+"%%%1%%% 
+
+%%%2%%%"
+`;
+
+exports[`integration no-translate directive with leaf: skeleton main 1`] = `
+"%%%0%%% 
+
+::no-translate [some inline content will no be translated]"
+`;
+
+exports[`integration no-translate directive with leaf: xliff expr 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+    <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+        <header>
+            <skeleton>
+                <external-file href=\\"file.skl\\"></external-file>
+            </skeleton>
+        </header>
+        <body>
+            <trans-unit id=\\"1\\">
+                <source xml:space=\\"preserve\\">This will be translated</source>
+            </trans-unit>
+            <trans-unit id=\\"2\\">
+                <source xml:space=\\"preserve\\">::no-translate [some inline content will no be translated]</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>"
+`;
+
+exports[`integration no-translate directive with leaf: xliff main 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"file.ext\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"file.skl\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"0\\">
+        <source xml:space=\\"preserve\\">This will be translated</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
 exports[`integration recursive merge tokens: skeleton expr 1`] = `"%%%1%%%"`;
 
 exports[`integration recursive merge tokens: skeleton main 1`] = `"%%%1%%%"`;

--- a/src/integration/index.spec.ts
+++ b/src/integration/index.spec.ts
@@ -522,3 +522,23 @@ test('inline: space with code 8239')`
 test('inline: space with code 8287')`
 Предложение номер один [title](link). [title](link) предложение номер два.
 `;
+
+test('no-translate directive with block')`
+This will be translated 
+
+:::no-translate
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+:::
+`;
+
+test('no-translate directive with leaf')`
+This will be translated 
+
+::no-translate [some inline content will no be translated]
+`;
+
+test('no-translate directive with inline')`
+Use :no-translate[**GET /api/v1/users**] to list users and :no-translate[POST /api/v1/users] to create.
+`;

--- a/src/skeleton/index.ts
+++ b/src/skeleton/index.ts
@@ -21,6 +21,7 @@ import {customRenderer} from 'src/renderer';
 import {Hash, hash as _hash} from 'src/hash';
 import {Consumer} from 'src/consumer';
 import {Liquid} from 'src/skeleton/liquid';
+import {noTranslate} from 'src/directives/no-translate';
 
 import term from './plugins/term';
 import includes from './plugins/includes';
@@ -46,6 +47,7 @@ export function skeleton(markdown: string, options: SkeletonOptions = {}, hash: 
     md.normalizeLinkText = (a: string) => a;
 
     // diplodoc plugins
+    md.use(noTranslate(), diplodocOptions);
     md.use(meta, diplodocOptions);
     md.use(includes, diplodocOptions);
     md.use(notes, diplodocOptions);

--- a/src/skeleton/rules/index.ts
+++ b/src/skeleton/rules/index.ts
@@ -8,6 +8,7 @@ import {blockquote} from './blockquote';
 import {code} from './code';
 import {html} from './html';
 import {list} from './list';
+import {noTranslate} from './no-translate';
 
 export const rules: Renderer.RenderRuleRecord = {
     ...text,
@@ -18,4 +19,5 @@ export const rules: Renderer.RenderRuleRecord = {
     ...code,
     ...html,
     ...list,
+    ...noTranslate,
 };

--- a/src/skeleton/rules/no-translate.ts
+++ b/src/skeleton/rules/no-translate.ts
@@ -1,0 +1,15 @@
+import type Renderer from 'markdown-it/lib/renderer';
+import type {CustomRenderer} from 'src/renderer';
+
+import {Consumer} from 'src/consumer';
+import {Liquid} from 'src/skeleton/liquid';
+
+export const noTranslate: Renderer.RenderRuleRecord = {
+    no_translate_inline: function (this: CustomRenderer<Consumer>, tokens: Token[], idx) {
+        const token = tokens[idx];
+        const noTranslateContent = Liquid.unescape(token.attrGet('data-content') || '');
+
+        token.skip = [`:no-translate[${noTranslateContent}]`];
+        return '';
+    },
+};

--- a/src/xliff/md-xliff/rules/index.ts
+++ b/src/xliff/md-xliff/rules/index.ts
@@ -9,6 +9,7 @@ import {image} from './image';
 import {video} from './video';
 import {file} from './file';
 import {htmlInline} from './html-inline';
+import {noTranslate} from './no-translate';
 
 // blocks(container and leaf) create group
 export const rules = {
@@ -27,6 +28,7 @@ export const rules = {
     blockquote_close: () => '',
     list_item_open: () => '',
     list_item_close: () => '',
+    ...noTranslate,
     ...diplodocRules,
     ...breaks,
     ...pair,

--- a/src/xliff/md-xliff/rules/no-translate.ts
+++ b/src/xliff/md-xliff/rules/no-translate.ts
@@ -1,0 +1,15 @@
+import type Renderer from 'markdown-it/lib/renderer';
+
+import {generateX} from 'src/xliff/generator';
+
+export const noTranslate: Renderer.RenderRuleRecord = {
+    no_translate_inline: noTranslateInline,
+};
+
+function noTranslateInline(tokens: Token[], i: number) {
+    const token = tokens[i];
+    const type = token.type;
+    const skip = token.skip;
+
+    return generateX({ctype: type, equivText: (skip || '').toString()});
+}

--- a/src/xliff/xliff-md/index.ts
+++ b/src/xliff/xliff-md/index.ts
@@ -126,6 +126,9 @@ export class XLFMDRenderer {
 
             // html
             html_inline: literal,
+
+            // no-translate
+            no_translate_inline: literal,
         };
     }
 


### PR DESCRIPTION
### No-translate directive

Adds new directive 'no-translate' which allows to mark content as none translatable.

Examples:

#### Block directive

:::no-translate
Should not be translated.
Can use **markup** inside.
:::

#### Leaf directive

::no-translate [**C:\Program Files\Application\config.ini**]
::no-translate [~/Documents/project/src/main.rs]

#### Inline directive

- :no-translate[GET /api/v1/users] — get all users
- :no-translate[POST /api/v1/auth/login] — authorization
- :no-translate[PUT /api/v1/users/{id}] — update users data
